### PR TITLE
Adds docker-compose.yml file, CMD to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,3 +38,6 @@ ADD ./contrib/supervisor/conf.d /etc/supervisor/conf.d
 
 # Add services
 ADD ./contrib/docker/services /etc/service
+
+# run the init script
+CMD /sbin/my_init

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+# should we add hostname to dockerfile
+
+solr:
+  image: lukecampbell/docker-ckan-solr
+  container_name: solr
+  # use ports ranges as string
+  # See https://docs.docker.com/compose/compose-file/#ports
+  ports:
+    - "8983:8983"
+
+postgis:
+  image: lukecampbell/docker-ckan-postgis
+  container_name: postgis
+  ports:
+    - "5432:5432"
+  # Override these in a production environment
+  environment:
+    - POSTGRES_USER=ckanadmin
+    - POSTGRES_PASS=ckanadmin
+    - POSTGRES_DB=ckan
+
+redis:
+  image: redis:3.0.7-alpine
+  container_name: redis
+  ports:
+    - "6379:6379" 
+
+ioos-catalog:
+  build: .
+  container_name: docker-ioos-catalog-test
+  hostname: catalog-dev.asa.rocks
+  links:
+    - redis
+    - postgis:db
+    - solr
+  environment:
+    - CKAN_INIT=true
+    - CKAN_SERVER_NAME=http://catalog-dev.asa.rocks/catalog/
+  ports:
+    - "80:80"


### PR DESCRIPTION
Adds a docker-compose.yml file to allow for easier deploys.
Adds a CMD block to Dockerfile to run `my_init` script by default on
`docker run`.
Should be considered experimental for now.  Re-running `docker-compose`
can cause issues with CKAN attempting to access the database prior to
initialization.